### PR TITLE
Support Python paths other than C:\Python27

### DIFF
--- a/install/install-on-windows.cmd
+++ b/install/install-on-windows.cmd
@@ -1,9 +1,20 @@
 @echo off
+echo "Finding Python installation"
+where py
+IF %ERRORLEVEL% NEQ 0 GOTO :readpath
+py -2.7 -c "import sys; print (sys.prefix);" > pythonpathtmp.txt
+GOTO :readpath
+:nopy
+python -c "import sys; print (sys.prefix);" > pythonpathtmp.txt
+:readpath
+set /p PYTHON_PATH=<pythonpathtmp.txt
+del pythonpathtmp.txt
+
 echo "Symlinking library"
-mklink /j C:\Python27\Lib\site-packages\aktos_dcs "%~dp0\aktos_dcs"
+mklink /j %PYTHON_PATH%\Lib\site-packages\aktos_dcs "%~dp0\aktos_dcs"
 echo "installing dependencies"
-C:\Python27\Scripts\pip install -r "%~dp0\requirements.txt"
-C:\Python27\Scripts\pip install "%~dp0\dep\%PROCESSOR_ARCHITECTURE%\*"
+pip2.7 install -r "%~dp0\requirements.txt"
+pip2.7 install "%~dp0\dep\%PROCESSOR_ARCHITECTURE%\*"
 echo.
 echo Finished...
 echo. 


### PR DESCRIPTION
I have Python installed somewhere other than C:\Python27. This change helped. Also handling the case where py, which comes with Python 3, does not exist.